### PR TITLE
Update osd.h

### DIFF
--- a/src/osd/headless/public/osd.h
+++ b/src/osd/headless/public/osd.h
@@ -8,7 +8,7 @@ typedef uint32_t (*ItemGetStateFunc)(void *device_internal, void *item_internal)
 
 extern NSString *const MAMEErrorDomain;
 
-typedef NS_ENUM(NSInteger, MAMEError)
+typedef NS_ERROR_ENUM(MAMEErrorDomain, MAMEError)
 {
 	MAMEErrorUnsupportedROM = -1,
 	MAMEErrorAuditFailed    = -2,


### PR DESCRIPTION
Use `NS_ERROR_ENUM` instead of `NS_ENUM` for error enums. This provides some help with Swift code.